### PR TITLE
Add affected components

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -46,7 +46,17 @@ type VulnerabilityMetadata struct {
 type VulnerabilityStatement struct {
 	Metadata        VulnerabilityMetadata `json:"vulnerability"`
 	Status          string                `json:"status"`
+	Products        []Product             `json:"products"`
 	ImpactStatement string                `json:"impact_statement,omitempty"`
+}
+
+type Product struct {
+	ID            string       `json:"@id"`
+	Subcomponents []Components `json:"subcomponents"`
+}
+
+type Components struct {
+	ID string `json:"@id"`
 }
 
 // NewVulnerabilityReport creates a vulnerability report from a govulncheckreport
@@ -157,6 +167,10 @@ func renderResult(b *bytes.Buffer, statement *VulnerabilityStatement, n int) {
 	fmt.Fprintf(b, "%s\n", statement.Metadata.Description)
 	fmt.Fprintf(b, "More info: %s\n", statement.Metadata.ID)
 
+	if statement.Products != nil {
+		renderProducts(b, statement.Products)
+	}
+
 	switch statement.Status {
 	case ResultTypeAffected:
 		b.WriteString(output.ErrorSprintf("Your code is affected by this vulnerability\n"))
@@ -167,6 +181,19 @@ func renderResult(b *bytes.Buffer, statement *VulnerabilityStatement, n int) {
 	default:
 	}
 	b.WriteString("\n")
+}
+
+func renderProducts(b *bytes.Buffer, products []Product) {
+	if len(products) > 0 {
+		fmt.Fprintf(b, "Affected products: \n")
+
+		for i := range products {
+
+			for j := range products[i].Subcomponents {
+				fmt.Fprintf(b, " - %s\n", products[i].Subcomponents[j].ID)
+			}
+		}
+	}
 }
 
 func (v *VulnerabilityReport) renderFailedIgnores(b *bytes.Buffer) {

--- a/report/report.go
+++ b/report/report.go
@@ -188,7 +188,6 @@ func renderProducts(b *bytes.Buffer, products []Product) {
 		fmt.Fprintf(b, "Affected products: \n")
 
 		for i := range products {
-
 			for j := range products[i].Subcomponents {
 				fmt.Fprintf(b, " - %s\n", products[i].Subcomponents[j].ID)
 			}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -133,6 +133,16 @@ func TestReportRendering(t *testing.T) {
 						Description: "A description of GO-2025-0001",
 					},
 					Status: "affected",
+					Products: []Product{
+						{
+							ID: "an id",
+							Subcomponents: []Components{
+								{
+									ID: "pkg:golang/stdlib@v1.24.1",
+								},
+							},
+						},
+					},
 				},
 				{
 					Metadata: VulnerabilityMetadata{
@@ -165,6 +175,11 @@ func TestReportRendering(t *testing.T) {
 					So(strings.Contains(reportOutput, vcreport.Statements[i].Metadata.Description), ShouldBeTrue)
 					So(strings.Contains(reportOutput, vcreport.Statements[i].Metadata.ID), ShouldBeTrue)
 					So(strings.Contains(reportOutput, vcreport.Statements[i].Metadata.Name), ShouldBeTrue)
+					for j := range vcreport.Statements[i].Products {
+						for k := range vcreport.Statements[i].Products[j].Subcomponents {
+							So(strings.Contains(reportOutput, vcreport.Statements[i].Products[j].Subcomponents[k].ID), ShouldBeTrue)
+						}
+					}
 				}
 			})
 		})


### PR DESCRIPTION
### What

Add affected components to report.

### How to review

Check looks ok. 

You can test by:

- run make install
- go to a go app running on go1.24.1 and running it or by overriding in the config.
- see it does something like this (observe affected products):

```
Vulnerability #4: GO-2025-3751
Sensitive headers not cleared on cross-origin redirect in net/http
More info: https://pkg.go.dev/vuln/GO-2025-3751
Affected products: 
 - pkg:golang/stdlib@v1.24.1
Your code is affected by this vulnerability
```

### Who can review

Not me. 