### PR TITLE
Bump go version to 1.26.2

### DIFF
--- a/.dis-vulncheck.yaml
+++ b/.dis-vulncheck.yaml
@@ -1,2 +1,2 @@
 ---
-toolchain: go1.25.1
+toolchain: go1.26.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 
 # Single source of truth for tool versions
 env:
-  GO_VERSION: '1.25'
-  GOLANGCI_LINT_VERSION: 'v2.5.0'
+  GO_VERSION: '1.26'
+  GOLANGCI_LINT_VERSION: 'v2.11.4'
 
 jobs:
   dis-vulncheck-audit:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dis-vulncheck
 
-go 1.25
+go 1.26
 
 require (
 	github.com/ONSdigital/log.go/v2 v2.5.0


### PR DESCRIPTION
### What

- 1.25.1 is affected by [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4946)
- Fixed in minor releases https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU
- Bumping to 1.26.2

### How to review

- Audit test pass

### Who can review

!Me